### PR TITLE
renamed parse-server branch master -> alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "jsdoc-babel": "0.5.0",
     "lint-staged": "10.5.3",
     "metro-react-native-babel-preset": "0.59.0",
-    "parse-server": "github:parse-community/parse-server#master",
+    "parse-server": "github:parse-community/parse-server#alpha",
     "prettier": "2.2.1",
     "regenerator-runtime": "0.13.5",
     "vinyl-source-stream": "2.0.0"


### PR DESCRIPTION
The parse community has renamed branches and renamed the master `branch` to `alpha`